### PR TITLE
check if ~/.hearsayrc exists before sourcing

### DIFF
--- a/hearsay-server/src/main/assembly/bin/setenv
+++ b/hearsay-server/src/main/assembly/bin/setenv
@@ -1,3 +1,7 @@
 
 . ~/.bashrc
-. ~/.hearsayrc
+
+if [ -e ~/.hearsayrc ]
+then
+  . ~/.hearsayrc
+fi


### PR DESCRIPTION
If .hearsayrc is required, there should be an example somewhere. If not required, its absence should not prevent starting the server.
